### PR TITLE
Added Hugo shortcodes for `perex` and `tip` sections

### DIFF
--- a/layouts/shortcodes/perex.html
+++ b/layouts/shortcodes/perex.html
@@ -1,0 +1,3 @@
+<div class="admonition perex">
+    <p>{{ printf "%s" .Inner | markdownify }}</p>
+</div>

--- a/layouts/shortcodes/tip.html
+++ b/layouts/shortcodes/tip.html
@@ -1,0 +1,4 @@
+<div class="admonition tip">
+    <p class="admonition-title">{{ .Get "title" }}</p>
+    <p>{{ printf "%s" .Inner | markdownify }}</p>
+</div>


### PR DESCRIPTION
http://gohugo.io/extras/shortcodes

Their templates should be customized and styled.
The important thing is that they can be used from MD files in #4 and on.