### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ Deploy site `vercel`.
 
 ## Development
 
-See [how to contribute](https://contributte.org/contributing.html) to this package.
-
-This package is currently maintaining by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">


### PR DESCRIPTION
Updates the Development section to use past tense as per archive template requirements.

## Changes
- Changed "is currently maintaining" to "was maintained"
- Removed "See how to contribute" line (not relevant for archived projects)

Follows the Option C template from `.ai/archive-repo.md` for website/site projects.